### PR TITLE
Fix build for aarch64-unknown-linux-gnu

### DIFF
--- a/rs-drivelist/Cargo.toml
+++ b/rs-drivelist/Cargo.toml
@@ -21,5 +21,5 @@ json = "0.12"
 [target.x86_64-pc-windows-msvc.dependencies]
 winapi = { version= "0.3", features=["setupapi","winioctl","windef","handleapi","errhandlingapi","winerror","cfgmgr32","handleapi","fileapi","ioapiset","winbase","processenv"] }
 
-[target.x86_64-unknown-linux-gnu.dependencies]
+[target.'cfg(target_os = "linux")'.dependencies]
 regex = "1"


### PR DESCRIPTION
Looks like it should work fine on other linux platforms, e.g. aarch64